### PR TITLE
Fix Jest test failures properly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         run: pnpm lint || true
 
       - name: Run unit and API tests
-        run: pnpm test -- --passWithNoTests
+        run: pnpm test
         env:
           NEXT_PUBLIC_SITE_NAME: "NextJS Image Processor"
           NEXT_PUBLIC_SITE_DESCRIPTION: "A powerful web application for processing images"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest --passWithNoTests",
+    "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:e2e": "playwright test"


### PR DESCRIPTION
- Rewrite cleanup.test.js with correct imports and mocks
- Fix serve-image.test.js with proper NextResponse mocking
- Update GitHub workflow to run tests normally
- Remove unnecessary test configuration files