### PR TITLE
Fix Docker build workflow and test initialization errors

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -36,19 +36,23 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v41
         with:
-          files_ignore: |
-            **/__tests__/**
-            **/e2e/**
-            **/*.md
-            .github/workflows/test.yml
-            .github/workflows/accessibility.yml
+          files_yaml: |
+            src:
+              - '!**/__tests__/**'
+              - '!**/e2e/**'
+              - '!**/*.md'
+              - '!.github/workflows/test.yml'
+              - '!.github/workflows/accessibility.yml'
+              - '**'
 
       - name: Output build decision
         run: |
-          if [[ "${{ steps.changed-files.outputs.any_changed }}" == "true" || ("${{ github.event_name }}" == "push" && "${{ github.ref }}" =~ ^refs/tags/ ) ]]; then
+          if [[ "${{ steps.changed-files.outputs.src_any_changed }}" == "true" || ("${{ github.event_name }}" == "push" && "${{ github.ref }}" =~ ^refs/tags/ ) ]]; then
             echo "Building Docker images because relevant files have changed or this is a tag push"
+            echo "SHOULD_BUILD=true" >> $GITHUB_ENV
           else
             echo "Skipping Docker build because only test files were changed"
+            echo "SHOULD_BUILD=false" >> $GITHUB_ENV
           fi
 
       - name: Read version
@@ -56,11 +60,11 @@ jobs:
         run: echo "VERSION=$(cat version.txt)" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        if: steps.changed-files.outputs.any_changed == 'true' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+        if: env.SHOULD_BUILD == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        if: (steps.changed-files.outputs.any_changed == 'true' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))) && github.event_name != 'pull_request'
+        if: env.SHOULD_BUILD == 'true' && github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -69,7 +73,7 @@ jobs:
 
       # Build and push main application image
       - name: Extract metadata for main app
-        if: steps.changed-files.outputs.any_changed == 'true' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+        if: env.SHOULD_BUILD == 'true'
         id: meta-app
         uses: docker/metadata-action@v5
         with:
@@ -82,7 +86,7 @@ jobs:
             type=sha,format=short
 
       - name: Build and push main app image
-        if: steps.changed-files.outputs.any_changed == 'true' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+        if: env.SHOULD_BUILD == 'true'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -94,7 +98,7 @@ jobs:
 
       # Build and push cleanup service image
       - name: Extract metadata for cleanup service
-        if: steps.changed-files.outputs.any_changed == 'true' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+        if: env.SHOULD_BUILD == 'true'
         id: meta-cleanup
         uses: docker/metadata-action@v5
         with:
@@ -107,7 +111,7 @@ jobs:
             type=sha,format=short
 
       - name: Build and push cleanup service image
-        if: steps.changed-files.outputs.any_changed == 'true' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+        if: env.SHOULD_BUILD == 'true'
         uses: docker/build-push-action@v5
         with:
           context: .


### PR DESCRIPTION
- Improve Docker build workflow to properly detect relevant file changes
- Use files_yaml with precise patterns instead of files_ignore
- Add SHOULD_BUILD environment variable for cleaner conditionals
- Fix test initialization errors by defining mocks before imports
- Ensure tests properly fail the build when they don't pass
- Prevent unnecessary Docker builds when only test files change