### PR TITLE
Fix test environment issues and Docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -45,8 +45,9 @@ jobs:
               - '!**/__tests__/**'
               - '!**/e2e/**'
               - '!**/*.md'
-              - '!.github/workflows/test.yml'
-              - '!.github/workflows/accessibility.yml'
+              - '!.github/workflows/**'
+              - '!jest.*.js'
+              - '!**/__mocks__/**'
               - '**'
 
       - name: Output build decision

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         run: pnpm lint || true
 
       - name: Run unit and API tests
-        run: pnpm test -- --passWithNoTests --testEnvironment=node
+        run: NODE_ENV=test-node pnpm test -- --passWithNoTests --testEnvironment=node
         env:
           NEXT_PUBLIC_SITE_NAME: "NextJS Image Processor"
           NEXT_PUBLIC_SITE_DESCRIPTION: "A powerful web application for processing images"

--- a/__tests__/api/serve-image.test.js
+++ b/__tests__/api/serve-image.test.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 // Mock the NextResponse before importing the route
 const mockJson = jest.fn();
 const mockNextResponse = jest.fn();
@@ -37,55 +41,55 @@ describe('Serve Image API', () => {
   beforeEach(() => {
     // Reset all mocks
     jest.clearAllMocks();
-    
+
     // Set up default mock implementations
     mockJson.mockImplementation((data, options) => ({
       status: options?.status || 200,
       headers: new Map(Object.entries(options?.headers || {})),
       json: async () => data
     }));
-    
+
     mockNextResponse.mockImplementation((body, init) => ({
       status: init?.status || 200,
       headers: new Map(Object.entries(init?.headers || {})),
       body
     }));
-    
+
     path.join.mockImplementation((...args) => args.join('/'));
     path.extname.mockImplementation((filename) => {
       const parts = filename.split('.');
       return parts.length > 1 ? `.${parts.pop()}` : '';
     });
-    
+
     fs.existsSync.mockReturnValue(true);
     fsPromises.readFile.mockResolvedValue(Buffer.from('test image data'));
-    
+
     // Mock process.cwd()
     jest.spyOn(process, 'cwd').mockReturnValue('/test/path');
   });
-  
+
   test('should return 400 if no filename is provided', async () => {
     // Arrange
     const request = { url: 'http://localhost:3000/api/serve-image' };
-    
+
     // Act
     await GET(request);
-    
+
     // Assert
     expect(mockJson).toHaveBeenCalledWith(
       { error: 'No filename provided' },
       { status: 400 }
     );
   });
-  
+
   test('should return 404 if the file does not exist', async () => {
     // Arrange
     const request = { url: 'http://localhost:3000/api/serve-image?file=test.jpg' };
     fs.existsSync.mockReturnValue(false);
-    
+
     // Act
     await GET(request);
-    
+
     // Assert
     expect(mockJson).toHaveBeenCalledWith(
       { error: 'File not found' },

--- a/__tests__/unit/cleanup.test.js
+++ b/__tests__/unit/cleanup.test.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 // Import the function to test
 const { cleanupOldUploads } = require('../../app/utils/cleanup');
 
@@ -31,10 +35,10 @@ describe('Cleanup Utility', () => {
   beforeEach(() => {
     // Reset all mocks
     jest.clearAllMocks();
-    
+
     // Mock process.cwd()
     jest.spyOn(process, 'cwd').mockReturnValue('/test/path');
-    
+
     // Set up default mock implementations
     path.join.mockImplementation((...args) => args.join('/'));
     fs.existsSync.mockReturnValue(true);
@@ -42,26 +46,26 @@ describe('Cleanup Utility', () => {
     fsPromises.stat.mockResolvedValue({ mtimeMs: Date.now() });
     fsPromises.unlink.mockResolvedValue(undefined);
   });
-  
+
   test('should return early if uploads directory does not exist', async () => {
     // Arrange
     fs.existsSync.mockReturnValue(false);
-    
+
     // Act
     const result = await cleanupOldUploads();
-    
+
     // Assert
     expect(result).toEqual({ deleted: 0, errors: 0 });
     expect(fsPromises.readdir).not.toHaveBeenCalled();
   });
-  
+
   test('should delete files older than the specified age', async () => {
     // Arrange
     const now = Date.now();
     jest.spyOn(Date, 'now').mockReturnValue(now);
-    
+
     fsPromises.readdir.mockResolvedValue(['file1.jpg', 'file2.png', '.gitkeep']);
-    
+
     fsPromises.stat.mockImplementation((filePath) => {
       if (filePath.includes('file1')) {
         return Promise.resolve({ mtimeMs: now - 2 * 60 * 60 * 1000 }); // 2 hours old
@@ -69,10 +73,10 @@ describe('Cleanup Utility', () => {
         return Promise.resolve({ mtimeMs: now - 30 * 60 * 1000 }); // 30 minutes old
       }
     });
-    
+
     // Act
     const result = await cleanupOldUploads(60 * 60 * 1000); // 1 hour
-    
+
     // Assert
     expect(fsPromises.unlink).toHaveBeenCalledTimes(1);
     expect(fsPromises.unlink).toHaveBeenCalledWith('/test/path/public/uploads/file1.jpg');

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ const createJestConfig = nextJest({
 // Add any custom config to be passed to Jest
 const customJestConfig = {
   setupFilesAfterEnv: [
-    '<rootDir>/jest.setup.js',
+    process.env.NODE_ENV === 'test-node' ? '<rootDir>/jest.node.setup.js' : '<rootDir>/jest.setup.js',
   ],
   testEnvironment: 'jest-environment-jsdom',
   testMatch: [

--- a/jest.node.setup.js
+++ b/jest.node.setup.js
@@ -1,0 +1,49 @@
+// Setup file for Node.js environment tests
+
+// Mock environment variables
+process.env.NEXT_PUBLIC_SITE_NAME = 'NextJS Image Processor Test';
+process.env.NEXT_PUBLIC_SITE_DESCRIPTION = 'Test environment for image processing';
+process.env.NEXT_PUBLIC_SITE_URL = 'http://localhost:3000';
+process.env.CLEANUP_API_KEY = 'test-api-key';
+
+// Mock the Next.js router
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn(),
+    pathname: '/',
+    query: {},
+  }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Mock next/server
+jest.mock('next/server', () => {
+  const mockJson = jest.fn((data, options = {}) => ({
+    status: options.status || 200,
+    headers: new Map(Object.entries(options.headers || {})),
+    json: async () => data,
+  }));
+
+  const mockRedirect = jest.fn((url) => ({
+    status: 302,
+    headers: new Map([['Location', url]]),
+  }));
+
+  return {
+    NextResponse: {
+      json: mockJson,
+      redirect: mockRedirect,
+    },
+  };
+});
+
+// Silence console output in tests
+console.log = jest.fn();
+console.error = jest.fn();
+console.warn = jest.fn();

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -62,50 +62,58 @@ process.env.CLEANUP_API_KEY = 'test-api-key';
 
 // We're using manual mocks for next/server in __mocks__/next/server.js
 
-// Mock canvas for testing
-global.HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
-  fillRect: jest.fn(),
-  clearRect: jest.fn(),
-  getImageData: jest.fn(() => ({
-    data: new Array(4).fill(0),
-  })),
-  putImageData: jest.fn(),
-  createImageData: jest.fn(() => []),
-  setTransform: jest.fn(),
-  drawImage: jest.fn(),
-  save: jest.fn(),
-  restore: jest.fn(),
-  scale: jest.fn(),
-  rotate: jest.fn(),
-  translate: jest.fn(),
-  transform: jest.fn(),
-  fillText: jest.fn(),
-  measureText: jest.fn(() => ({ width: 0 })),
-  fillStyle: 'white',
-}));
+// Mock canvas for testing only if in a browser environment
+if (typeof window !== 'undefined' && typeof HTMLCanvasElement !== 'undefined') {
+  global.HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+    fillRect: jest.fn(),
+    clearRect: jest.fn(),
+    getImageData: jest.fn(() => ({
+      data: new Array(4).fill(0),
+    })),
+    putImageData: jest.fn(),
+    createImageData: jest.fn(() => []),
+    setTransform: jest.fn(),
+    drawImage: jest.fn(),
+    save: jest.fn(),
+    restore: jest.fn(),
+    scale: jest.fn(),
+    rotate: jest.fn(),
+    translate: jest.fn(),
+    transform: jest.fn(),
+    fillText: jest.fn(),
+    measureText: jest.fn(() => ({ width: 0 })),
+    fillStyle: 'white',
+  }));
+}
 
 // Mock crypto for testing
-global.crypto = {
-  randomBytes: jest.fn(() => ({
-    toString: jest.fn(() => 'test-random-string'),
-  })),
-  subtle: {
-    digest: jest.fn(),
-  },
-  getRandomValues: jest.fn(() => new Uint8Array(16)),
-};
+if (!global.crypto) {
+  global.crypto = {
+    randomBytes: jest.fn(() => ({
+      toString: jest.fn(() => 'test-random-string'),
+    })),
+    subtle: {
+      digest: jest.fn(),
+    },
+    getRandomValues: jest.fn(() => new Uint8Array(16)),
+  };
+}
 
-// Mock URL.createObjectURL and URL.revokeObjectURL
-global.URL.createObjectURL = jest.fn(() => 'blob:test-url');
-global.URL.revokeObjectURL = jest.fn();
+// Mock URL.createObjectURL and URL.revokeObjectURL if in a browser environment
+if (typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function') {
+  global.URL.createObjectURL = jest.fn(() => 'blob:test-url');
+  global.URL.revokeObjectURL = jest.fn();
+}
 
-// Mock fetch
-global.fetch = jest.fn(() =>
-  Promise.resolve({
-    ok: true,
-    json: () => Promise.resolve({}),
-    text: () => Promise.resolve(''),
-    blob: () => Promise.resolve(new Blob()),
-    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-  })
-);
+// Mock fetch if not already defined
+if (!global.fetch) {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({}),
+      text: () => Promise.resolve(''),
+      blob: () => Promise.resolve(typeof Blob !== 'undefined' ? new Blob() : {}),
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    })
+  );
+}


### PR DESCRIPTION
- Fix jest.setup.js to conditionally mock browser-specific APIs
- Create separate jest.node.setup.js for Node.js environments
- Update jest.config.js to use the appropriate setup file
- Set NODE_ENV=test-node in GitHub workflow
- Add @jest-environment node annotations to test files
- Improve Docker build workflow to ignore all test-related files