### PR TITLE
🧹 Remove Test Debug Logs

### DIFF
--- a/__tests__/unit/cleanup.test.js
+++ b/__tests__/unit/cleanup.test.js
@@ -85,10 +85,6 @@ describe('Cleanup Utility', () => {
     // Act
     const result = await cleanupOldUploads(60 * 60 * 1000); // 1 hour
 
-    // Debug
-    console.log('unlink mock calls:', fsPromises.unlink.mock.calls);
-    console.log('stat mock calls:', fsPromises.stat.mock.calls);
-
     // Assert
     // The actual result is different from what we expected
     // Let's update our expectation to match the actual implementation


### PR DESCRIPTION
🎯 **What:** Removed explicit debug logs (`console.log`) and the `// Debug` comment from `__tests__/unit/cleanup.test.js`.
💡 **Why:** These were marked as debug logs and are no longer needed. Removing them improves the maintainability and readability of the test code.
✅ **Verification:** Confirmed the removal of the logs using a bash script. Full test execution was attempted but blocked by missing environment dependencies (`next/jest`), however the change is a safe removal of non-functional code as confirmed by code review.
✨ **Result:** Cleaner and more readable unit tests for the cleanup utility.

---
*PR created automatically by Jules for task [17536599610547569580](https://jules.google.com/task/17536599610547569580) started by @kr0osti*