### PR TITLE
🔒 restrict CORS origin in proxy route

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `app/api/cleanup/route.js` had a hardcoded default secret (`change-this-to-a-secure-key`) that would allow an attacker to bypass authentication if `process.env.CLEANUP_API_KEY` was missing from the server environment.
 **Learning:** Providing a "fallback" string for secrets creates a backdoor if deployment environments fail to set the environment variable. This allows the endpoint to become inadvertently public.
 **Prevention:** Rather than using a fallback secret, an endpoint should throw an error (e.g. 500) or refuse to start if a required environment variable is not defined.
+
+## 2024-05-24 - [Overly Permissive CORS in Proxy Route]
+**Vulnerability:** The `app/api/proxy/route.ts` used `Access-Control-Allow-Origin: '*'`, allowing any website to make cross-origin requests to this endpoint.
+**Learning:** Using a wildcard for CORS origin can expose sensitive endpoints to unauthorized cross-origin access and potential data leakage.
+**Prevention:** Restrict `Access-Control-Allow-Origin` to specific, trusted origins (e.g., using `process.env.NEXT_PUBLIC_SITE_URL`) or omit the header entirely if not needed.

--- a/app/api/proxy/route.ts
+++ b/app/api/proxy/route.ts
@@ -54,11 +54,25 @@ export async function GET(request: NextRequest) {
     const contentType = response.headers.get('content-type') || 'application/octet-stream';
     const buffer = await response.arrayBuffer();
 
+    // Security: Restrict CORS to prevent unauthorized cross-origin access.
+    // We only allow our own application to access this proxy.
+    const origin = request.headers.get('origin');
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+    let allowedOrigin = '';
+
+    if (siteUrl && origin === new URL(siteUrl).origin) {
+      allowedOrigin = origin;
+    } else if (!origin) {
+      // Allow requests without Origin header (e.g., direct browser access)
+      allowedOrigin = '';
+    }
+
     return new NextResponse(buffer, {
       headers: {
         'Content-Type': contentType,
         'Cache-Control': 'public, max-age=86400',
-        'Access-Control-Allow-Origin': '*'
+        'Vary': 'Origin',
+        ...(allowedOrigin && { 'Access-Control-Allow-Origin': allowedOrigin })
       }
     });
   } catch (error) {


### PR DESCRIPTION
🎯 **What:** Restricted overly permissive CORS in the image proxy route.
⚠️ **Risk:** The previous wildcard configuration (`Access-Control-Allow-Origin: '*'`) allowed any website to use the server as an open proxy and potentially access proxied images cross-origin without authorization.
🛡️ **Solution:** Implemented a check against `process.env.NEXT_PUBLIC_SITE_URL` to only allow the application's own origin. Added the `Vary: Origin` header to ensure responses are cached correctly for different origins.

---
*PR created automatically by Jules for task [11119699334857560150](https://jules.google.com/task/11119699334857560150) started by @kr0osti*