### PR TITLE
🧹 remove leftover debug logging in cleanup utility

### DIFF
--- a/app/utils/cleanup.js
+++ b/app/utils/cleanup.js
@@ -13,7 +13,6 @@ export async function cleanupOldUploads(maxAgeMs = 60 * 60 * 1000) { // Default:
   
   // Check if uploads directory exists
   if (!existsSync(uploadsDir)) {
-    console.log('Uploads directory does not exist, nothing to clean up');
     return { deleted: 0, errors: 0 };
   }
   
@@ -26,8 +25,6 @@ export async function cleanupOldUploads(maxAgeMs = 60 * 60 * 1000) { // Default:
     // Skip .gitkeep file if it exists
     const filesToProcess = files.filter(file => file !== '.gitkeep');
     
-    console.log(`Checking ${filesToProcess.length} files for cleanup...`);
-    
     for (const file of filesToProcess) {
       const filePath = path.join(uploadsDir, file);
       
@@ -39,7 +36,6 @@ export async function cleanupOldUploads(maxAgeMs = 60 * 60 * 1000) { // Default:
         if (fileAge > maxAgeMs) {
           await unlink(filePath);
           deleted++;
-          console.log(`Deleted old file: ${file} (age: ${Math.round(fileAge / 1000 / 60)} minutes)`);
         }
       } catch (err) {
         console.error(`Error processing file ${file}:`, err);
@@ -47,7 +43,6 @@ export async function cleanupOldUploads(maxAgeMs = 60 * 60 * 1000) { // Default:
       }
     }
     
-    console.log(`Cleanup complete. Deleted ${deleted} files, encountered ${errors} errors.`);
     return { deleted, errors };
   } catch (error) {
     console.error('Error cleaning up old uploads:', error);


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the presence of leftover debug logging in the `cleanupOldUploads` function. I removed four `console.log` statements that provided progress updates which were deemed redundant for production code.

💡 **Why:** Removing these logs improves maintainability and readability by reducing noise in the application logs. It ensures that only essential information (like errors) is logged, making it easier to identify real issues.

✅ **Verification:** I confirmed the deletions by reading the file after modification to ensure no syntax errors were introduced and that all `console.error` calls were correctly preserved for reporting legitimate failures.

✨ **Result:** A cleaner utility function that adheres better to production coding standards by not polluting standard output with debug information.

---
*PR created automatically by Jules for task [882801477935028224](https://jules.google.com/task/882801477935028224) started by @kr0osti*