### PR TITLE
🧪 Add unit tests for robots.ts metadata

### DIFF
--- a/__tests__/unit/robots.test.ts
+++ b/__tests__/unit/robots.test.ts
@@ -1,0 +1,44 @@
+import robots from '../../app/robots';
+
+describe('robots', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should return robots configuration with default site URL when NEXT_PUBLIC_SITE_URL is not set', () => {
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+
+    const result = robots();
+
+    expect(result).toEqual({
+      rules: {
+        userAgent: '*',
+        allow: '/',
+        disallow: '/api/',
+      },
+      sitemap: 'https://yourdomain.com/sitemap.xml',
+    });
+  });
+
+  it('should return robots configuration with custom site URL when NEXT_PUBLIC_SITE_URL is set', () => {
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://example.com';
+
+    const result = robots();
+
+    expect(result).toEqual({
+      rules: {
+        userAgent: '*',
+        allow: '/',
+        disallow: '/api/',
+      },
+      sitemap: 'https://example.com/sitemap.xml',
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** Missing tests for robots.ts metadata.
📊 **Coverage:** Added tests for both default site URL and custom `NEXT_PUBLIC_SITE_URL` scenarios in `app/robots.ts`.
✨ **Result:** Improved test coverage for metadata routes, ensuring correct robots.txt generation.

---
*PR created automatically by Jules for task [6988134597620328958](https://jules.google.com/task/6988134597620328958) started by @kr0osti*