### PR TITLE
🧹 Conditionally wrap debug logs in production code

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -151,10 +151,9 @@ export default function ImageProcessor() {
   }, [imageUrls])
 
   const addLog = (message: string) => {
-    // Check if DEBUG is enabled - add more explicit logging to debug the issue
-    console.log(`Debug setting: ${process.env.NEXT_PUBLIC_DEBUG}`)
-
     if (process.env.NEXT_PUBLIC_DEBUG === 'true') {
+      // Check if DEBUG is enabled - add more explicit logging to debug the issue
+      console.log(`Debug setting: ${process.env.NEXT_PUBLIC_DEBUG}`)
       console.log(`[${new Date().toLocaleTimeString()}] ${message}`)
     }
   }

--- a/components/debug-info.tsx
+++ b/components/debug-info.tsx
@@ -4,18 +4,20 @@ import { useEffect } from 'react';
 
 export function DebugInfo() {
   useEffect(() => {
-    console.log("Debug Info Component Loaded");
-    console.log("NEXT_PUBLIC_DEBUG value:", process.env.NEXT_PUBLIC_DEBUG);
-    
-    // Log all environment variables that start with NEXT_PUBLIC_
-    const publicEnvVars = Object.keys(process.env)
-      .filter(key => key.startsWith('NEXT_PUBLIC_'))
-      .reduce((obj, key) => {
-        obj[key] = process.env[key];
-        return obj;
-      }, {} as Record<string, string | undefined>);
-    
-    console.log("All public env vars:", publicEnvVars);
+    if (process.env.NEXT_PUBLIC_DEBUG === 'true' || process.env.NODE_ENV === 'development') {
+      console.log("Debug Info Component Loaded");
+      console.log("NEXT_PUBLIC_DEBUG value:", process.env.NEXT_PUBLIC_DEBUG);
+
+      // Log all environment variables that start with NEXT_PUBLIC_
+      const publicEnvVars = Object.keys(process.env)
+        .filter(key => key.startsWith('NEXT_PUBLIC_'))
+        .reduce((obj, key) => {
+          obj[key] = process.env[key];
+          return obj;
+        }, {} as Record<string, string | undefined>);
+
+      console.log("All public env vars:", publicEnvVars);
+    }
   }, []);
 
   // Only render in development or when debug is enabled


### PR DESCRIPTION
This PR improves code health by ensuring that debug logs and environment variable details are only output to the console when explicitly enabled via `NEXT_PUBLIC_DEBUG` or when running in development mode.

### Changes:
- **components/debug-info.tsx**: The mount logs and environment variable listing are now gated by a check for `process.env.NEXT_PUBLIC_DEBUG === 'true' || process.env.NODE_ENV === 'development'`.
- **app/page.tsx**: The `console.log` showing the current debug setting in the `addLog` function has been moved inside the `if (process.env.NEXT_PUBLIC_DEBUG === 'true')` block to prevent it from appearing on every log attempt in production.

These changes improve maintainability by reducing console noise in production and preventing accidental exposure of public environment variables in the console logs.

---
*PR created automatically by Jules for task [12485527382985800517](https://jules.google.com/task/12485527382985800517) started by @kr0osti*