### PR TITLE
🔒 security fix: SSRF via Open Redirect in fetch

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The `fetchImagesFromUrl` action and `/api/proxy` endpoint fetched user-provided URLs without validating the target host, allowing potential access to internal services and private network resources.
 **Learning:** Server-side fetching of user-provided URLs is a high-risk operation. Validating the hostname string is insufficient as attackers can use DNS rebinding to point a public domain to a private IP address.
 **Prevention:** Implement a robust URL validation utility that checks for safe protocols, blocks private/reserved IP ranges, and performs DNS resolution to verify the actual IP address being accessed.
+
+## 2026-05-10 - [SSRF via Open Redirect in fetch]
+**Vulnerability:** The `fetch` API follows redirects by default. While the initial URL was validated against a safe-list/IP-check, an attacker could provide a URL that redirects to an internal, restricted URL (e.g., `http://169.254.169.254/`), bypassing the initial check.
+**Learning:** Security validation must occur at every step of a request chain. Validating only the initial URL is insufficient if the client automatically follows redirects.
+**Prevention:** Use `redirect: 'manual'` in fetch options and manually validate every URL in the redirect chain before following it.

--- a/__tests__/utils/ssrf.test.ts
+++ b/__tests__/utils/ssrf.test.ts
@@ -1,9 +1,12 @@
-import { isSafeUrl } from '../../lib/ssrf';
+import { isSafeUrl, safeFetch } from '../../lib/ssrf';
 import dns from 'dns';
 
 jest.mock('dns', () => ({
   lookup: jest.fn(),
 }));
+
+// Mock global fetch
+global.fetch = jest.fn();
 
 describe('isSafeUrl', () => {
   const originalEnv = process.env;
@@ -73,5 +76,71 @@ describe('isSafeUrl', () => {
     it('should still block non-http/https protocols', async () => {
       expect(await isSafeUrl('file:///etc/passwd')).toBe(false);
     });
+  });
+});
+
+describe('safeFetch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch safe URLs', async () => {
+    (dns.lookup as unknown as jest.Mock).mockImplementation((hostname, options, callback) => {
+      callback(null, [{ address: '93.184.216.34' }]);
+    });
+    (global.fetch as jest.Mock).mockResolvedValue({
+      status: 200,
+      ok: true
+    });
+
+    const response = await safeFetch('https://example.com');
+    expect(response.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ redirect: 'manual' }));
+  });
+
+  it('should block unsafe initial URLs', async () => {
+    (dns.lookup as unknown as jest.Mock).mockImplementation((hostname, options, callback) => {
+      callback(null, [{ address: '127.0.0.1' }]);
+    });
+
+    await expect(safeFetch('http://127.0.0.1')).rejects.toThrow('SSRF Blocked');
+  });
+
+  it('should follow safe redirects', async () => {
+    (dns.lookup as unknown as jest.Mock).mockImplementation((hostname, options, callback) => {
+      callback(null, [{ address: '93.184.216.34' }]);
+    });
+
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        status: 301,
+        headers: new Map([['location', 'https://example.com/new']])
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true
+      });
+
+    const response = await safeFetch('https://example.com/old');
+    expect(response.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch).toHaveBeenNthCalledWith(2, 'https://example.com/new', expect.any(Object));
+  });
+
+  it('should block unsafe redirects', async () => {
+    (dns.lookup as unknown as jest.Mock).mockImplementation((hostname, options, callback) => {
+      if (hostname === 'example.com') {
+        callback(null, [{ address: '93.184.216.34' }]);
+      } else {
+        callback(null, [{ address: '127.0.0.1' }]);
+      }
+    });
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      status: 301,
+      headers: new Map([['location', 'http://localhost/secret']])
+    });
+
+    await expect(safeFetch('https://example.com/redirect-to-internal')).rejects.toThrow('SSRF Blocked: Unsafe URL: http://localhost/secret');
   });
 });

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import * as cheerio from "cheerio"
-import { isSafeUrl } from "@/lib/ssrf"
+import { isSafeUrl, safeFetch } from "@/lib/ssrf"
 
 // Add this interface to define image metadata
 export interface ImageMetadata {
@@ -27,12 +27,6 @@ export async function fetchImagesFromUrl(url: string, customBaseUrl?: string) {
   try {
     logs.push(`Starting to fetch URL: ${url}`)
 
-    // Security: Validate the URL to prevent SSRF
-    if (!(await isSafeUrl(url))) {
-      logs.push(`Security error: Blocked potentially unsafe URL: ${url}`)
-      return { error: "The provided URL is not allowed for security reasons.", logs }
-    }
-
     // Determine base URL for resolving relative paths
     let baseUrl: string
     try {
@@ -44,7 +38,8 @@ export async function fetchImagesFromUrl(url: string, customBaseUrl?: string) {
     }
 
     // Fetch the HTML content from the URL
-    const response = await fetch(url, {
+    // Security: Use safeFetch to prevent SSRF and validate redirect chain
+    const response = await safeFetch(url, {
       headers: {
         "User-Agent":
           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
@@ -160,6 +155,10 @@ export async function fetchImagesFromUrl(url: string, customBaseUrl?: string) {
     logs.push(`Found ${imageUrls.length} unique images`)
     return { imageUrls, imageMetadata, logs }
   } catch (error) {
+    if (error instanceof Error && error.message.includes('SSRF Blocked')) {
+      logs.push(`Security error: ${error.message}`)
+      return { error: "The provided URL is not allowed for security reasons.", logs }
+    }
     const errorMessage = error instanceof Error ? error.message : "Unknown error"
     logs.push(`Error in fetchImagesFromUrl: ${errorMessage}`)
     console.error("Error in fetchImagesFromUrl:", error)

--- a/app/api/proxy/route.ts
+++ b/app/api/proxy/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createRateLimiter } from '../../utils/rate-limit.js';
-import { isSafeUrl } from '@/lib/ssrf';
+import { isSafeUrl, safeFetch } from '@/lib/ssrf';
 
 // Create a rate limiter for the proxy endpoint
 // Allow 500 requests per minute per IP address
@@ -35,13 +35,9 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'URL parameter is required' }, { status: 400 });
   }
 
-  // Security: Validate the URL to prevent SSRF
-  if (!(await isSafeUrl(url))) {
-    return NextResponse.json({ error: 'The provided URL is not allowed for security reasons.' }, { status: 403 });
-  }
-
   try {
-    const response = await fetch(url, {
+    // Security: Use safeFetch to prevent SSRF and validate redirect chain
+    const response = await safeFetch(url, {
       headers: {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
         "Accept": "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
@@ -82,6 +78,9 @@ export async function GET(request: NextRequest) {
       }
     });
   } catch (error) {
+    if (error instanceof Error && error.message.includes('SSRF Blocked')) {
+      return NextResponse.json({ error: 'The provided URL is not allowed for security reasons.' }, { status: 403 });
+    }
     console.error('Proxy error:', error);
     return NextResponse.json({ error: 'Failed to proxy image' }, { status: 500 });
   }

--- a/lib/ssrf.ts
+++ b/lib/ssrf.ts
@@ -103,3 +103,36 @@ export async function isSafeUrl(urlStr: string): Promise<boolean> {
     return false;
   }
 }
+
+/**
+ * A wrapper around fetch that prevents SSRF by validating the URL
+ * and all redirects against isSafeUrl.
+ */
+export async function safeFetch(
+  url: string,
+  options: RequestInit = {},
+  maxRedirects: number = 5
+): Promise<Response> {
+  let currentUrl = url;
+  let redirects = 0;
+
+  while (true) {
+    if (!(await isSafeUrl(currentUrl))) {
+      throw new Error(`SSRF Blocked: Unsafe URL: ${currentUrl}`);
+    }
+
+    // Disable automatic redirects to validate each step in the redirect chain
+    const response = await fetch(currentUrl, { ...options, redirect: 'manual' });
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location || redirects >= maxRedirects) return response;
+
+      currentUrl = new URL(location, currentUrl).toString();
+      redirects++;
+      continue;
+    }
+
+    return response;
+  }
+}


### PR DESCRIPTION
🎯 **What:** Fixed an SSRF vulnerability where attackers could bypass URL validation by using redirects.
⚠️ **Risk:** Attackers could potentially access internal services or sensitive data (like cloud metadata) by redirecting a trusted request to a restricted internal URL.
🛡️ **Solution:** Implemented a `safeFetch` utility that disables automatic redirects (`redirect: 'manual'`) and manually validates every URL in the redirect chain before proceeding. Both the image proxy and the scraping action now use this utility.

---
*PR created automatically by Jules for task [5559021412021237699](https://jules.google.com/task/5559021412021237699) started by @kr0osti*